### PR TITLE
Use newer stuff and some refactorings

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -47,7 +47,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<executions>
 					<execution>

--- a/ejb/interface/src/main/java/io/tracee/examples/ejb/TestEjb.java
+++ b/ejb/interface/src/main/java/io/tracee/examples/ejb/TestEjb.java
@@ -2,9 +2,6 @@ package io.tracee.examples.ejb;
 
 import javax.ejb.Remote;
 
-/**
- * Created by Tobias Gindler, holisticon AG on 16.01.14.
- */
 @Remote
 public interface TestEjb {
 

--- a/jaxws/client/pom.xml
+++ b/jaxws/client/pom.xml
@@ -57,13 +57,11 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<scope>compile</scope>
 		</dependency>
 
 		<!-- tracee related dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,9 @@
 		<module>docker</module>
 	</modules>
 
-
 	<name>tracee-examples</name>
 	<description>Please refer to https://github.com/tracee/tracee.</description>
 	<url>https://github.com/tracee/tracee</url>
-
 
 	<properties>
 		<!-- TracEE Version -->
@@ -39,17 +37,15 @@
 		<!-- versions of test dependencies -->
 		<junit.version>4.12</junit.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<mockito.version>1.10.8</mockito.version>
-		<powermock.version>1.5.6</powermock.version>
 
 		<!-- dependency versions -->
 		<aspectj.version>1.7.4</aspectj.version>
-		<slf4j.version>1.6.6</slf4j.version>
-		<log4j.version>1.2.4</log4j.version>
-		<log4j2.version>2.0.2</log4j2.version>
-		<logback.version>0.9.30</logback.version>
-		<gson.version>2.2.4</gson.version>
-		<spring.version>3.0.7.RELEASE</spring.version>
+		<slf4j.version>1.7.13</slf4j.version>
+		<log4j.version>1.2.17</log4j.version>
+		<log4j2.version>2.5</log4j2.version>
+		<logback.version>1.1.3</logback.version>
+		<gson.version>2.5</gson.version>
+		<spring.version>3.2.16.RELEASE</spring.version>
 	</properties>
 
 	<build>
@@ -69,39 +65,39 @@
 			<plugins>
 				<plugin>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>2.5</version>
+					<version>3.0.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>2.6</version>
+					<version>2.7</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.2</version>
+					<version>3.3</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.7</source>
+						<target>1.7</target>
 					</configuration>
 				</plugin>
 				<plugin>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>2.8</version>
+					<version>2.10</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.5</version>
+					<version>2.6</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-war-plugin</artifactId>
-					<version>2.5</version>
+					<version>2.6</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.18</version>
+					<version>2.19.1</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.18</version>
+					<version>2.19.1</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-install-plugin</artifactId>
@@ -294,35 +290,19 @@
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
-				<version>1.0.7</version>
-				<scope>provided</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>ch.qos.logback</groupId>
-				<artifactId>logback-core</artifactId>
-				<version>1.0.7</version>
-				<scope>provided</scope>
+				<version>${logback.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
 				<version>${slf4j.version}</version>
-				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>servlet-api</artifactId>
 				<version>2.5</version>
-				<scope>provided</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>javax.ejb</groupId>
-				<artifactId>ejb-api</artifactId>
-				<version>3.0</version>
 				<scope>provided</scope>
 			</dependency>
 
@@ -336,12 +316,6 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-webmvc</artifactId>
-				<version>${spring.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.springframework</groupId>
-				<artifactId>spring-web</artifactId>
 				<version>${spring.version}</version>
 			</dependency>
 
@@ -391,12 +365,6 @@
 			<version>${hamcrest.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>${mockito.version}</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<organization>
@@ -438,7 +406,7 @@
 	<inceptionYear>2013</inceptionYear>
 
 	<prerequisites>
-		<maven>3.1.0</maven>
+		<maven>3.2.0</maven>
 	</prerequisites>
 
 	<issueManagement>

--- a/webapp/src/test/java/io/tracee/examples/webapp/logaccess/LogMessageProviderTest.java
+++ b/webapp/src/test/java/io/tracee/examples/webapp/logaccess/LogMessageProviderTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import java.util.Calendar;
 
 /**
- * @Test class for {@link io.tracee.examples.webapp.logaccess.LogMessageProvider}.
+ * @see class for {@link io.tracee.examples.webapp.logaccess.LogMessageProvider}.
  */
 public class LogMessageProviderTest {
 
@@ -61,7 +61,4 @@ public class LogMessageProviderTest {
 		logMessageProvider.getTimestamp(givenTimestampStr);
 
 	}
-
-
-
 }


### PR DESCRIPTION
Since we extracted the examples there is no need to use the same legacy versions of Java or the APIs. With this PR i've raised some versions (Java to 7, we already have built with java 7!!), spring, logback, log4j(2) etc.
So we can check that TracEE is running with the latest version of the APIs as well ;-)
